### PR TITLE
Add commonly required fields for products and variants in query strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ test
 
 *.local
 .vscode
+.idea

--- a/product.go
+++ b/product.go
@@ -129,6 +129,7 @@ var productQuery = fmt.Sprintf(`
 					name
 					value
 				}
+				position
 				image {
 					id
 					altText
@@ -178,6 +179,7 @@ var productBulkQuery = fmt.Sprintf(`
 					name
 					value
 				}
+				position
 				image {
 					id
 					altText

--- a/product.go
+++ b/product.go
@@ -84,6 +84,7 @@ const productBaseQuery = `
 	tags
 	title
 	description
+	descriptionPlainSummary
 	priceRangeV2{
 		minVariantPrice{
 			amount
@@ -104,6 +105,14 @@ const productBaseQuery = `
 		title
 	}
 	templateSuffix
+	customProductType
+	featuredImage{
+		id
+		altText
+		height
+		width
+		url
+	}
 `
 
 var productQuery = fmt.Sprintf(`
@@ -113,10 +122,19 @@ var productQuery = fmt.Sprintf(`
 			node{
 				id
 				legacyResourceId
+				title
+				displayName
 				sku
 				selectedOptions{
 					name
 					value
+				}
+				image {
+					id
+					altText
+					height
+					width
+					url
 				}
 				compareAtPrice
 				price
@@ -125,6 +143,7 @@ var productQuery = fmt.Sprintf(`
 					id
 					legacyResourceId							
 				}
+				availableForSale
 			}
 		}
 		pageInfo{
@@ -152,12 +171,20 @@ var productBulkQuery = fmt.Sprintf(`
 			node{
 				id
 				legacyResourceId
+				title
+				displayName
 				sku
 				selectedOptions{
 					name
 					value
 				}
-				position
+				image {
+					id
+					altText
+					height
+					width
+					url
+				}
 				compareAtPrice
 				price
 				inventoryQuantity
@@ -165,6 +192,7 @@ var productBulkQuery = fmt.Sprintf(`
 					id
 					legacyResourceId							
 				}
+				availableForSale
 			}
 		}
 	}


### PR DESCRIPTION
There were some fields which would be commonly required for a lot of usecases which were missing from the query strings, even though the Product and ProductVariant models had these fields included in their structs. Since adding these extra fields seems to have no consequence on the actual latency of the call, I thought it would be a good idea to include these for anyone else using this package to interact with the shopify admin-graphql API.

Also ignore JetBrains IDE config files.