### PR TITLE
Added context to every functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,25 +20,26 @@ export STORE_NAME=<store_name>
 package main
 
 import (
-    "fmt"
+	"context"
+	"fmt"
 
-    shopify "github.com/r0busta/go-shopify-graphql/v7"
+	shopify "github.com/r0busta/go-shopify-graphql/v7"
 )
 
 func main() {
-    // Create client
-    client := shopify.NewDefaultClient()
+	// Create client
+	client := shopify.NewDefaultClient()
 
-    // Get all collections
-    collections, err := client.Collection.ListAll()
-    if err != nil {
-        panic(err)
-    }
+	// Get all collections
+	collections, err := client.Collection.ListAll(context.Background())
+	if err != nil {
+		panic(err)
+	}
 
-    // Print out the result
-    for _, c := range collections {
-        fmt.Println(c.Handle)
-    }
+	// Print out the result
+	for _, c := range collections {
+		fmt.Println(c.Handle)
+	}
 }
 ```
 

--- a/bulk_test.go
+++ b/bulk_test.go
@@ -1,6 +1,7 @@
 package shopify_test
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -60,7 +61,7 @@ func TestBulkOperationEndToEnd(t *testing.T) {
 			}`
 
 			res := []*model.Product{}
-			err := tt.client.BulkOperation.BulkQuery(q, &res)
+			err := tt.client.BulkOperation.BulkQuery(context.Background(), q, &res)
 			require.NoError(t, err)
 
 			assert.Greater(t, len(res), 1)

--- a/example/bulk.go
+++ b/example/bulk.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/r0busta/go-shopify-graphql-model/v3/graph/model"
-	shopify "github.com/r0busta/go-shopify-graphql/v7"
+	"github.com/r0busta/go-shopify-graphql/v7"
 )
 
 func bulk(client *shopify.Client) {
@@ -39,7 +40,7 @@ func bulk(client *shopify.Client) {
 	}`
 
 	products := []*model.Product{}
-	err := client.BulkOperation.BulkQuery(q, &products)
+	err := client.BulkOperation.BulkQuery(context.Background(), q, &products)
 	if err != nil {
 		panic(err)
 	}

--- a/example/collections.go
+++ b/example/collections.go
@@ -1,14 +1,15 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
-	shopify "github.com/r0busta/go-shopify-graphql/v7"
+	"github.com/r0busta/go-shopify-graphql/v7"
 )
 
 func collections(client *shopify.Client) {
 	// Get all collections
-	collections, err := client.Collection.ListAll()
+	collections, err := client.Collection.ListAll(context.Background())
 	if err != nil {
 		panic(err)
 	}

--- a/example/products.go
+++ b/example/products.go
@@ -1,14 +1,15 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
-	shopify "github.com/r0busta/go-shopify-graphql/v7"
+	"github.com/r0busta/go-shopify-graphql/v7"
 )
 
 func products(client *shopify.Client) {
 	// Get products
-	products, err := client.Product.List("")
+	products, err := client.Product.List(context.Background(), "")
 	if err != nil {
 		panic(err)
 	}

--- a/fulfillment.go
+++ b/fulfillment.go
@@ -9,7 +9,7 @@ import (
 
 //go:generate mockgen -destination=./mock/fulfillment_service.go -package=mock . FulfillmentService
 type FulfillmentService interface {
-	Create(input model.FulfillmentV2Input) error
+	Create(ctx context.Context, input model.FulfillmentV2Input) error
 }
 
 type FulfillmentServiceOp struct {
@@ -24,13 +24,13 @@ type mutationFulfillmentCreateV2 struct {
 	} `graphql:"fulfillmentCreateV2(fulfillment: $fulfillment)" json:"fulfillmentCreateV2"`
 }
 
-func (s *FulfillmentServiceOp) Create(fulfillment model.FulfillmentV2Input) error {
+func (s *FulfillmentServiceOp) Create(ctx context.Context, fulfillment model.FulfillmentV2Input) error {
 	m := mutationFulfillmentCreateV2{}
 
 	vars := map[string]interface{}{
 		"fulfillment": fulfillment,
 	}
-	err := s.client.gql.Mutate(context.Background(), &m, vars)
+	err := s.client.gql.Mutate(ctx, &m, vars)
 	if err != nil {
 		return fmt.Errorf("mutation: %w", err)
 	}

--- a/inventory.go
+++ b/inventory.go
@@ -9,9 +9,9 @@ import (
 
 //go:generate mockgen -destination=./mock/inventory_service.go -package=mock . InventoryService
 type InventoryService interface {
-	Update(id string, input model.InventoryItemUpdateInput) error
-	Adjust(locationID string, input []model.InventoryAdjustItemInput) error
-	ActivateInventory(locationID string, id string) error
+	Update(ctx context.Context, id string, input model.InventoryItemUpdateInput) error
+	Adjust(ctx context.Context, locationID string, input []model.InventoryAdjustItemInput) error
+	ActivateInventory(ctx context.Context, locationID string, id string) error
 }
 
 type InventoryServiceOp struct {
@@ -38,13 +38,13 @@ type mutationInventoryActivate struct {
 	} `graphql:"inventoryActivate(inventoryItemId: $itemID, locationId: $locationId)" json:"inventoryActivate"`
 }
 
-func (s *InventoryServiceOp) Update(id string, input model.InventoryItemUpdateInput) error {
+func (s *InventoryServiceOp) Update(ctx context.Context, id string, input model.InventoryItemUpdateInput) error {
 	m := mutationInventoryItemUpdate{}
 	vars := map[string]interface{}{
 		"id":    id,
 		"input": input,
 	}
-	err := s.client.gql.Mutate(context.Background(), &m, vars)
+	err := s.client.gql.Mutate(ctx, &m, vars)
 	if err != nil {
 		return fmt.Errorf("mutation: %w", err)
 	}
@@ -56,13 +56,13 @@ func (s *InventoryServiceOp) Update(id string, input model.InventoryItemUpdateIn
 	return nil
 }
 
-func (s *InventoryServiceOp) Adjust(locationID string, input []model.InventoryAdjustItemInput) error {
+func (s *InventoryServiceOp) Adjust(ctx context.Context, locationID string, input []model.InventoryAdjustItemInput) error {
 	m := mutationInventoryBulkAdjustQuantityAtLocation{}
 	vars := map[string]interface{}{
 		"locationId":               locationID,
 		"inventoryItemAdjustments": input,
 	}
-	err := s.client.gql.Mutate(context.Background(), &m, vars)
+	err := s.client.gql.Mutate(ctx, &m, vars)
 	if err != nil {
 		return fmt.Errorf("mutation: %w", err)
 	}
@@ -74,13 +74,13 @@ func (s *InventoryServiceOp) Adjust(locationID string, input []model.InventoryAd
 	return nil
 }
 
-func (s *InventoryServiceOp) ActivateInventory(locationID string, id string) error {
+func (s *InventoryServiceOp) ActivateInventory(ctx context.Context, locationID string, id string) error {
 	m := mutationInventoryActivate{}
 	vars := map[string]interface{}{
 		"itemID":     id,
 		"locationId": locationID,
 	}
-	err := s.client.gql.Mutate(context.Background(), &m, vars)
+	err := s.client.gql.Mutate(ctx, &m, vars)
 	if err != nil {
 		return fmt.Errorf("mutation: %w", err)
 	}

--- a/location.go
+++ b/location.go
@@ -9,7 +9,7 @@ import (
 
 //go:generate mockgen -destination=./mock/location_service.go -package=mock . LocationService
 type LocationService interface {
-	Get(id string) (*model.Location, error)
+	Get(ctx context.Context, id string) (*model.Location, error)
 }
 
 type LocationServiceOp struct {
@@ -18,7 +18,7 @@ type LocationServiceOp struct {
 
 var _ LocationService = &LocationServiceOp{}
 
-func (s *LocationServiceOp) Get(id string) (*model.Location, error) {
+func (s *LocationServiceOp) Get(ctx context.Context, id string) (*model.Location, error) {
 	q := `query location($id: ID!) {
 		location(id: $id){
 			id
@@ -33,7 +33,7 @@ func (s *LocationServiceOp) Get(id string) (*model.Location, error) {
 	var out struct {
 		*model.Location `json:"location"`
 	}
-	err := s.client.gql.QueryString(context.Background(), q, vars, &out)
+	err := s.client.gql.QueryString(ctx, q, vars, &out)
 	if err != nil {
 		return nil, fmt.Errorf("query: %w", err)
 	}

--- a/variant.go
+++ b/variant.go
@@ -9,7 +9,7 @@ import (
 
 //go:generate mockgen -destination=./mock/variant_service.go -package=mock . VariantService
 type VariantService interface {
-	Update(variant model.ProductVariantInput) error
+	Update(ctx context.Context, variant model.ProductVariantInput) error
 }
 
 type VariantServiceOp struct {
@@ -24,13 +24,13 @@ type mutationProductVariantUpdate struct {
 	} `graphql:"productVariantUpdate(input: $input)" json:"productVariantUpdate"`
 }
 
-func (s *VariantServiceOp) Update(variant model.ProductVariantInput) error {
+func (s *VariantServiceOp) Update(ctx context.Context, variant model.ProductVariantInput) error {
 	m := mutationProductVariantUpdate{}
 
 	vars := map[string]interface{}{
 		"input": variant,
 	}
-	err := s.client.gql.Mutate(context.Background(), &m, vars)
+	err := s.client.gql.Mutate(ctx, &m, vars)
 	if err != nil {
 		return fmt.Errorf("mutation: %w", err)
 	}


### PR DESCRIPTION
All operations should take caller's context in order to support deadlines, cancellation signals, and other request-scoped values across API boundaries and between processes.

