### PR TITLE
Limit maximum variants in query to 100

### DIFF
--- a/product.go
+++ b/product.go
@@ -117,7 +117,7 @@ const productBaseQuery = `
 
 var productQuery = fmt.Sprintf(`
 	%s
-	variants(first:250, after: $cursor){
+	variants(first:100, after: $cursor){
 		edges{
 			node{
 				id


### PR DESCRIPTION
Since Shopify allows only 100 variants for each products, the `first` argument should not be over 100. It only makes the query cost to go high and reach Shopify limit.