### PR TITLE
Create function for creating private app client

### DIFF
--- a/client.go
+++ b/client.go
@@ -69,6 +69,10 @@ func NewDefaultClient() *Client {
 	return NewClient(WithGraphQLClient(gql))
 }
 
+func NewPrivateClient() *Client {
+	return NewClientWithToken(os.Getenv("STORE_PASSWORD"), os.Getenv("STORE_NAME"))
+}
+
 func NewClientWithToken(accessToken string, storeName string, opts ...Option) *Client {
 	if accessToken == "" || storeName == "" {
 		log.Fatalln("Shopify Admin API access token and/or store name not set")


### PR DESCRIPTION
`NewDefaultClient` doesn't work for private apps because `STORE_API_KEY` must be set but setting it prevents the `X-Shopify-Access-Token` header from being set in `RoundTrip`. 